### PR TITLE
Add generic objects

### DIFF
--- a/plugin/ninja-feet.vim
+++ b/plugin/ninja-feet.vim
@@ -51,8 +51,10 @@ function! s:map(lhs, rhs, mode)
 	endif
 endfunction
 
+onoremap <silent> <expr> <Plug>(ninja-left-foot)        <SID>map_expr("<SID>", '', '[', v:count1)
 onoremap <silent> <expr> <Plug>(ninja-left-foot-inner)  <SID>map_expr("<SID>", 'i', '[', v:count1)
 onoremap <silent> <expr> <Plug>(ninja-left-foot-a)      <SID>map_expr("<SID>", 'a', '[', v:count1)
+onoremap <silent> <expr> <Plug>(ninja-right-foot)       <SID>map_expr("<SID>", '', ']', v:count1)
 onoremap <silent> <expr> <Plug>(ninja-right-foot-inner) <SID>map_expr("<SID>", 'i', ']', v:count1)
 onoremap <silent> <expr> <Plug>(ninja-right-foot-a)     <SID>map_expr("<SID>", 'a', ']', v:count1)
 


### PR DESCRIPTION
Enables support for text objects that don't begin with `a` or `i`, such as vim-commentary's `gc`.