### PR TITLE
Account for register and remapped keys

### DIFF
--- a/plugin/ninja-feet.vim
+++ b/plugin/ninja-feet.vim
@@ -1,6 +1,7 @@
 function! s:ninja_prepare(mode, direction, count)
 	let s:direction = a:direction
 	let s:operator = v:operator
+	let s:register = '"' . v:register
 	let s:cursor_pos = getpos('.')
 	let s:operatorfunc = &operatorfunc
 	call feedkeys(a:count.a:mode)
@@ -24,7 +25,7 @@ function! s:ninja_strike(mode)
 			call setpos("'".s:direction, pos)
 		endif
 	endif
-	call feedkeys(s:operator.mode.s:direction)
+	call feedkeys(s:register.s:operator.mode.s:direction, 'n')
 endfunction
 
 function! s:ninja_insert(mode)

--- a/plugin/ninja-feet.vim
+++ b/plugin/ninja-feet.vim
@@ -29,13 +29,13 @@ function! s:ninja_strike(mode)
 	" Upon feeding the keys, however, s:register would overtake as the active
 	" register. To get around that:
 	" 1 - first record the active register,
-	let active_register = v:register
+	let active_register = '"' . v:register
 	" 2 - feed the keys with the recorded `s:register`,
 	call feedkeys(s:register.s:operator.mode.s:direction, 'n')
-	" 3 - then re-active the active register recorded on 1.
-	call feedkeys('"' . active_register . "\<Plug>NINJAFEET_ResetActiveRegister")
+	" 3 - then re-activate the active register recorded on 1.
+	call feedkeys(active_register."\<Plug>NINJAFEET_ActiveRegister")
 endfunction
-nnoremap <silent> <Plug>NINJAFEET_ResetActiveRegister <nop>
+nnoremap <silent> <Plug>NINJAFEET_ActiveRegister <nop>
 
 function! s:ninja_insert(mode)
 	let op = a:mode == 'line' ? 'O' : 'i'

--- a/plugin/ninja-feet.vim
+++ b/plugin/ninja-feet.vim
@@ -25,8 +25,17 @@ function! s:ninja_strike(mode)
 			call setpos("'".s:direction, pos)
 		endif
 	endif
+	" `s:register`, here, might not be the same as the current active register.
+	" Upon feeding the keys, however, s:register would overtake as the active
+	" register. To get around that:
+	" 1 - first record the active register,
+	let active_register = v:register
+	" 2 - feed the keys with the recorded `s:register`,
 	call feedkeys(s:register.s:operator.mode.s:direction, 'n')
+	" 3 - then re-active the active register recorded on 1.
+	call feedkeys('"' . active_register . "\<Plug>NINJAFEET_ResetActiveRegister")
 endfunction
+nnoremap <silent> <Plug>NINJAFEET_ResetActiveRegister <nop>
 
 function! s:ninja_insert(mode)
 	let op = a:mode == 'line' ? 'O' : 'i'


### PR DESCRIPTION
#### Account for register

Since the operator will be input again, the original register passed along it was being lost.

EDIT: I've caught another unwarranted behavior where the "original" register might not be the current active register, so the active register needs to be re-enabled again through a no-op mapping.

#### Account for remapped keys

Considering

```
nnoremap eD D
nnoremap D X
```

After inputting `eD]iw`, for instance, v:operator is `D`, so `D` would be fed instead of `eD`.

The problem is, since feedkeys remaps keys by default,
and `D` is mapped to `X`,
the resulting keys being fed would be `X]iw` instead of `D]iw`.

By passing in the flag `'n'` we ask it to use feed the non-remapped keys, since v:operator (`D`, from `eD`) is already the "real", non-remapped keybinding.