### PR TITLE
fix multiline char-wise operations to end of line

### DIFF
--- a/plugin/ninja-feet.vim
+++ b/plugin/ninja-feet.vim
@@ -10,21 +10,20 @@ function! s:ninja_strike(mode)
 	call setpos('.', s:cursor_pos)
 	let &operatorfunc = s:operatorfunc
 	let mode = a:mode == 'line' ? "'" : "`"
+	let inclusive_toggle = ''
 	if s:direction == ']'
 		" Manually adjust for inclusive behaviour.
-		" TODO: Find a cleaner solution
 		let pos = getpos("'".s:direction)
-		if mode == '`' && pos[2] == strlen(getline(pos[1]))
-			" End marks end of line. Just use $.
-			let mode = ''
-			let s:direction = '$'
+		if a:mode != 'line' && pos[2] == strlen(getline(pos[1]))
+			" Use inclusive behavior
+			let inclusive_toggle = 'v'
 		else
 			" Add one to the mark column position
 			let pos[2] = pos[2] + 1
 			call setpos("'".s:direction, pos)
 		endif
 	endif
-	call feedkeys(s:operator.mode.s:direction)
+	call feedkeys(s:operator.inclusive_toggle.mode.s:direction)
 endfunction
 
 function! s:ninja_insert(mode)


### PR DESCRIPTION
Multiline character-wise operations that included the last character of the last affected line did not work properly. Consider the following code:

```c
void myFunc(
	int myThing1,
	int [|]myThing2,
	int myThing3
)
{ }
```
Where the cursor is at `[|]`.

Performing `d]a)` currently results in:
```c
void myFunc(
	int myThing1,
	int [|]
	int myThing3
)
{ }
```

This fix causes the same action to result in:
```c
void myFunc(
	int myThing1,
	int [|]
{ }

```
which is what you want.

The fix uses `o_v` (http://vimdoc.sourceforge.net/htmldoc/motion.html#o_v) to toggle the operation to be inclusive rather than exclusive.